### PR TITLE
Fix mac compilation issues, more build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,41 @@ make install
 cd ../..
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$PWD/install ../
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../install ../
 # configure GraviT
 make && make install
 ```
+
+## Building with volume rendering support
+
+Currently volume rendering support must be enabled at compile time. Rather than using the default `cmake` flags, instead build `GraviT` with the following `cmake` invocation:
+
+```
+embree_DIR=../third-party/embree cmake -DGVT_VOLUME=True -DGVT_RENDER_ADAPTER_GREGSPRAY=True -DGVT_VOL_APP=True -DGVT_TIMING=False -DGVT_TESTING=False -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../install ../
+```
+
+This turns on several compile-time flags needed by the volume renderer and disables the testing option, which currently conflicts with the volume renderer.
+
+## Building the Python interface
+
+Once you have build `GraviT` itself, you can optionally build the python bindings to `GraviT`, `pygvt`. To build them, navigate to the `pygvt` folder and build the cython wrapper around the `GraviT` C++ API:
+
+```
+cd pygvt
+embree_DIR=../third-party/embree/install gvt_DIR=../install/ IceT_LIB_DIR=../third-party/icet/install/lib MPI_DIR=/usr/local/ GregSpray_LIB_DIR=../third-party/GregSpray/install/lib python setup.py develop
+```
+
+If you would prefer to avoid setting these environment variables at the command line manually, you can source the `setenv.sh` script instead.
+
+You will need cython and setuptools installed in your python environment for this to work correctly. In addition, this assumes you have an MPI installation in `/usr/local`/ If your local MPI installation is in a different place, adjust `MPI_DIR`.
+
+Now you should be able to run the volume rendering example included with the `GraviT` repository:
+
+```
+LD_LIBRARY_PATH=../install/lib:../third-party/icet/install/lib:../third-party/embree/install/lib:../third-party/GregSpray/install/lib mpirun -np 2 python gvtVol.py
+```
+
+This will produce an image named `PythonVolRenderer.ppm` in the current directory.
 
 ## Design Philosophy
 

--- a/pygvt/src/gvt/gvt.pyx
+++ b/pygvt/src/gvt/gvt.pyx
@@ -12,32 +12,34 @@ from libcpp cimport bool
 
 
 cdef extern from "gravit/api.h" namespace "api":
-  void _gvtInit "api::gvtInit"(int argc, char** argv)
-  void _createMesh "api::createMesh"(string)
-  void _addMeshVertices "api::addMeshVertices"(string name, unsigned &n, float *vertices)
-  void _addMeshTriangles "api::addMeshTriangles"( string name,  unsigned &n,  unsigned *triangles)
-  void _addMeshFaceNormals "api::addMeshFaceNormals"( string name,  unsigned &n,  float *normals)
-  void _addMeshVertexNormals "api::addMeshVertexNormals"( string name,  unsigned &n,  float *normals)
-  void _finishMesh "api::finishMesh"( string name, bool compute_normal)
-  void _addMeshMaterial "api::addMeshMaterial"( string name,  unsigned mattype,  float *kd,  float alpha)
-  void _addMeshMaterial2 "api::addMeshMaterial"( string name,  unsigned mattype,  float *kd,  float *ks, float alpha )
-  void _addMeshMaterials "api::addMeshMaterials"( string name,  unsigned n,  unsigned *mattype,  float *kd, float *ks,  float *alpha)
-  void _addInstance "api::addInstance"(string name, string meshname, float *m)
-  void _createVolume"api::createVolume"(string name)
-  void _addVolumeTransferFunctions"api::addVolumeTransferFunctions"(string name, string colortfname, string opacityfname, float low, float high)
-  void _addVolumeSamples"api::addVolumeSamples"(string name, float *samples, int *counts, float *origin, float* deltas, float samplingrate)
-  void _addPointLight "api::addPointLight"(string name,  float *pos,  float *color)
-  void _addAreaLight "api::addAreaLight"(string name,  float *pos,  float *color,  float *n, float w, float h)
-  void _modifyLight "api::modifyLight"(string name,  float *pos,  float *color)
-  void _modifyLight "api::modifyLight"(string name,  float *pos,  float *color,  float *n, float w, float h)
-  void _addCamera "api::addCamera"(string name,  float *pos,  float *focus,  float *up, float fov, int depth, int samples, float jitter)
-  void _modifyCamera "api::modifyCamera"(string name,  float *pos,  float *focus,  float *up, float fov, int depth, int samples, float jitter)
-  void _modifyCamera "api::modifyCamera"(string name,  float *pos,  float *focus,  float *up, float fov)
-  void _addFilm "api::addFilm"(string name, int w, int h, string path)
-  void _modifyFilm "api::modifyFilm"(string name, int w, int h, string path)
-  void _render "api::render"(string name)
-  void _writeimage "api::writeimage"(string name, string output)
-  void _addRenderer "api::addRenderer"(string name, int adapter, int schedule)
+  void _gvtInit "gvtInit"(int argc, char** argv)
+  void _createMesh "createMesh"(string)
+  void _addMeshVertices "addMeshVertices"(string name, unsigned &n, float *vertices)
+  void _addMeshTriangles "addMeshTriangles"( string name,  unsigned &n,  unsigned *triangles)
+  void _addMeshFaceNormals "addMeshFaceNormals"( string name,  unsigned &n,  float *normals)
+  void _addMeshVertexNormals "addMeshVertexNormals"( string name,  unsigned &n,  float *normals)
+  void _finishMesh "finishMesh"( string name, bool compute_normal)
+  void _addMeshMaterial "addMeshMaterial"( string name,  unsigned mattype,  float *kd,  float alpha)
+  void _addMeshMaterial2 "addMeshMaterial"( string name,  unsigned mattype,  float *kd,  float *ks, float alpha )
+  void _addMeshMaterials "addMeshMaterials"( string name,  unsigned n,  unsigned *mattype,  float *kd, float *ks,  float *alpha)
+  void _addInstance "addInstance"(string name, string meshname, float *m)
+  void _createVolume"createVolume"(string name)
+  void _addVolumeTransferFunctions"addVolumeTransferFunctions"(string name, string colortfname, string opacityfname, float low, float high)
+  void _addVolumeSamples"addVolumeSamples"(string name, float *samples, int *counts, float *origin, float* deltas, float samplingrate)
+  void _addPointLight "addPointLight"(string name,  float *pos,  float *color)
+  void _addAreaLight "addAreaLight"(string name,  float *pos,  float *color,  float *n, float w, float h)
+  void _modifyLight "modifyLight"(string name,  float *pos,  float *color)
+  void _modifyLight "modifyLight"(string name,  float *pos,  float *color,  float *n, float w, float h)
+  void _addCamera "addCamera"(string name,  float *pos,  float *focus,  float *up, float fov, int depth, int samples, float jitter)
+  void _modifyCamera "modifyCamera"(string name,  float *pos,  float *focus,  float *up, float fov, int depth, int samples, float jitter)
+  void _modifyCamera "modifyCamera"(string name,  float *pos,  float *focus,  float *up, float fov)
+  void _addFilm "addFilm"(string name, int w, int h, string path)
+  void _modifyFilm "modifyFilm"(string name, int w, int h, string path)
+  void _render "render"(string name)
+  void _writeimage "writeimage"(string name, string output)
+  void _addRenderer "addRenderer"(string name, int adapter, int schedule,
+                                  string camera_name, string film_name,
+                                  bool volume)
 #void gvtInit(int &argc, char **&argv)
 
 def gvtInit():
@@ -121,8 +123,10 @@ def addFilm(str name, int w, int h, str path):
 def modifyFilm(str name, int w, int h, str path):
   _modifyFilm(name.encode(),w,h,path.encode())
 
-def addRenderer(str name, int adapter, int schedule):
-  _addRenderer(name.encode(),adapter,schedule)
+def addRenderer(str name, int adapter, int schedule, str camera_name,
+                str film_name, bool volume):
+  _addRenderer(name.encode(), adapter, schedule, camera_name.encode(),
+               film_name.encode(), volume)
 
 def render(str name):
   _render(name.encode())


### PR DESCRIPTION
I think @semeraro may have missed an API change in the `addRenderer` function, which I've fixed here in the cython wrapper.

In addition, with the recent changes, for some reason I *don't* need to prepend all the wrapped function names with `api::` (and in fact, doing so causes a compilation error).

With both of these issues fixed I'm able to run the python volume rendering example successfully. Hopefully we can iterate on the cython code so we have a version that builds both on my mac and on everyone else's development environment.

I also added some additional build instructions for the README.